### PR TITLE
Remove in memory zipping

### DIFF
--- a/benchviewer/main.py
+++ b/benchviewer/main.py
@@ -62,30 +62,31 @@ def download_data():
         )
         if file_paths or python_files_list:
             # print("file paths : ", file_paths)
-            return generate_zip(file_paths, python_files_list)
-            # zip_name = (
-            #     "MQTBench_" + datetime.now().strftime("%Y-%m-%d-%H-%M-%S") + ".zip"
-            # )
-            #
-            # @after_this_request
-            # def remove_file(response):
-            #     try:
-            #         os.remove(directory + filename)
-            #     except Exception as error:
-            #         app.logger.error(
-            #             "Error removing or closing downloaded file handle", error
-            #         )
-            #     return response
-            #
-            # return send_from_directory(
-            #     directory=directory,
-            #     path=filename,
-            #     as_attachment=True,
-            #     mimetype="application/zip",
-            #     download_name=zip_name,
-            # )
-        # else:
-        # print("No file paths are found")
+            # return generate_zip(file_paths, python_files_list)
+            directory, filename = generate_zip(file_paths, python_files_list)
+            zip_name = (
+                "MQTBench_" + datetime.now().strftime("%Y-%m-%d-%H-%M-%S") + ".zip"
+            )
+
+            @after_this_request
+            def remove_file(response):
+                try:
+                    os.remove(directory + filename)
+                except Exception as error:
+                    app.logger.error(
+                        "Error removing or closing downloaded file handle", error
+                    )
+                return response
+
+            return send_from_directory(
+                directory=directory,
+                path=filename,
+                as_attachment=True,
+                mimetype="application/zip",
+                download_name=zip_name,
+            )
+        else:
+            print("No file paths are found")
     return render_template(
         "index.html",
         benchmarks=benchmarks,

--- a/benchviewer/src/backend.py
+++ b/benchviewer/src/backend.py
@@ -453,8 +453,9 @@ def generate_zip(paths: list, python_files_list=None):
     import io
 
     fileobj = io.BytesIO()
-    # zip_name = zip_path + filename
-    with ZipFile(fileobj, "w") as zf:
+    zip_name = zip_path + filename
+    # with ZipFile(fileobj, "w") as zf:
+    with ZipFile(zip_name, "w") as zf:
 
         for individualFile in paths:
             zf.write(
@@ -470,15 +471,17 @@ def generate_zip(paths: list, python_files_list=None):
                 arcname="algo_level.txt",
                 compresslevel=1,
             )
-    fileobj.seek(0)
-
-    from flask import send_file
-    from datetime import datetime
-
-    zip_name = "MQTBench_" + datetime.now().strftime("%Y-%m-%d-%H-%M-%S") + ".zip"
-    return send_file(
-        fileobj, as_attachment=True, mimetype="application/zip", download_name=zip_name
-    )
+    directory = "./static/files/zip_tmp/"
+    return directory, filename
+    # fileobj.seek(0)
+    #
+    # from flask import send_file
+    # from datetime import datetime
+    #
+    # zip_name = "MQTBench_" + datetime.now().strftime("%Y-%m-%d-%H-%M-%S") + ".zip"
+    # return send_file(
+    #     fileobj, as_attachment=True, mimetype="application/zip", download_name=zip_name
+    # )
 
 
 def get_selected_file_paths(prepared_data):


### PR DESCRIPTION
With this PR, the zipping is done again by saving the generated zip files on storage instead of in memory only to avoid server problems if several users download all files at the same time.