### PR TITLE
Remove histogram functions

### DIFF
--- a/mqt/bench/benchmark_generator.py
+++ b/mqt/bench/benchmark_generator.py
@@ -57,10 +57,6 @@ def create_benchmarks_from_config(cfg_path: str):
         print("Read config successful")
 
     # global seetings
-    global save_png
-    save_png = cfg["save_png"]
-    global save_hist
-    save_hist = cfg["save_hist"]
     global max_depth
     max_depth = cfg["max_depth"]
     global timeout
@@ -311,21 +307,17 @@ def generate_benchmark(benchmark):
 
 def generate_circuits_on_all_levels(qc, num_qubits, file_precheck):
     characteristics = []
-    # filename_algo, depth = generate_algo_level_circuit(qc, n, save_png, save_hist)
+    # filename_algo, depth = generate_algo_level_circuit(qc, n)
     # characteristics.append([filename_algo, n, depth])
 
-    res_t_indep = generate_target_indep_level_circuit(
-        qc, num_qubits, save_png, save_hist, file_precheck
-    )
+    res_t_indep = generate_target_indep_level_circuit(qc, num_qubits, file_precheck)
 
     if res_t_indep:
         characteristics.extend(res_t_indep)
     else:
         return characteristics
 
-    res_t_dep = generate_target_dep_level_circuit(
-        qc, num_qubits, save_png, save_hist, file_precheck
-    )
+    res_t_dep = generate_target_dep_level_circuit(qc, num_qubits, file_precheck)
 
     if res_t_dep:
         characteristics.extend(res_t_dep)
@@ -336,12 +328,11 @@ def generate_circuits_on_all_levels(qc, num_qubits, file_precheck):
 
 
 def generate_algo_level_circuit(
-    qc: QuantumCircuit, num_qubits: int, save_png, save_hist
+    qc: QuantumCircuit,
+    num_qubits: int,
 ):
     characteristics = []
-    res = benchmark_generation_watcher(
-        utils.handle_algorithm_level, [qc, num_qubits, save_png, save_hist]
-    )
+    res = benchmark_generation_watcher(utils.handle_algorithm_level, [qc, num_qubits])
     characteristics.append(res)
 
     if res:
@@ -352,13 +343,13 @@ def generate_algo_level_circuit(
 
 
 def generate_target_indep_level_circuit(
-    qc: QuantumCircuit, num_qubits: int, save_png, save_hist, file_precheck
+    qc: QuantumCircuit, num_qubits: int, file_precheck
 ):
     characteristics = []
 
     res = benchmark_generation_watcher(
         utils.get_indep_level,
-        [qc, num_qubits, save_png, save_hist, file_precheck],
+        [qc, num_qubits, file_precheck],
     )
     if res:
         characteristics.append(res)
@@ -368,7 +359,7 @@ def generate_target_indep_level_circuit(
 
 
 def generate_target_dep_level_circuit(
-    qc: QuantumCircuit, num_qubits: int, save_png, save_hist, file_precheck
+    qc: QuantumCircuit, num_qubits: int, file_precheck
 ):
     characteristics = []
 
@@ -390,8 +381,6 @@ def generate_target_dep_level_circuit(
                         gate_set_name,
                         opt_level,
                         num_qubits,
-                        save_png,
-                        save_hist,
                         file_precheck,
                     ],
                 )
@@ -411,8 +400,6 @@ def generate_target_dep_level_circuit(
                         opt_level,
                         n_actual,
                         True,
-                        save_png,
-                        save_hist,
                         file_precheck,
                     ],
                 )
@@ -430,8 +417,6 @@ def generate_target_dep_level_circuit(
                         opt_level,
                         n_actual,
                         False,
-                        save_png,
-                        save_hist,
                         file_precheck,
                     ],
                 )

--- a/mqt/bench/tests/test_all.py
+++ b/mqt/bench/tests/test_all.py
@@ -71,7 +71,8 @@ def test_configure_begin():
 def test_quantumcircuit_algo_level(benchmark, num_qubits):
     qc = benchmark.create_circuit(num_qubits)
     filename_algo, depth, num_qubits = utils.handle_algorithm_level(
-        qc, num_qubits, save_png=False, save_hist=False
+        qc,
+        num_qubits,
     )
     assert depth > 0
 
@@ -113,11 +114,11 @@ def test_quantumcircuit_indep_level(benchmark, input_value, scalable):
     if scalable:
         assert qc.num_qubits == input_value
     filename_indep, depth, num_qubits = utils.get_indep_level(
-        qc, input_value, save_png=False, save_hist=False, file_precheck=False
+        qc, input_value, file_precheck=False
     )
     assert depth > 0
     filename_indep, depth, num_qubits = utils.get_indep_level(
-        qc, input_value, save_png=False, save_hist=False, file_precheck=True
+        qc, input_value, file_precheck=True
     )
     assert depth > 0
 
@@ -169,8 +170,6 @@ def test_quantumcircuit_native_and_mapped_levels(benchmark, input_value, scalabl
             gate_set_name,
             opt_level,
             input_value,
-            save_png=False,
-            save_hist=False,
             file_precheck=False,
         )
         assert depth_native > 0
@@ -180,8 +179,6 @@ def test_quantumcircuit_native_and_mapped_levels(benchmark, input_value, scalabl
             gate_set_name,
             opt_level,
             input_value,
-            save_png=False,
-            save_hist=False,
             file_precheck=True,
         )
         assert depth_native > 0
@@ -192,8 +189,6 @@ def test_quantumcircuit_native_and_mapped_levels(benchmark, input_value, scalabl
             opt_level,
             n_actual,
             False,
-            save_png=False,
-            save_hist=False,
             file_precheck=False,
         )
         assert depth_mapped > 0
@@ -204,8 +199,6 @@ def test_quantumcircuit_native_and_mapped_levels(benchmark, input_value, scalabl
             opt_level,
             n_actual,
             False,
-            save_png=False,
-            save_hist=False,
             file_precheck=True,
         )
         assert depth_mapped > 0
@@ -267,22 +260,6 @@ def test_rigetti_cmap_generator(num_circles: int):
 
 def test_get_google_c_map():
     assert len(utils.get_google_c_map()) == 176
-
-
-def test_save_circ():
-    qc = ghz.create_circuit(5)
-    utils.save_circ(qc, "pytest")
-    assert os.path.exists("hist_output/pytest.png")
-    if os.path.exists("hist_output/pytest.png"):
-        os.remove("hist_output/pytest.png")
-
-
-def test_sim_and_print_hist():
-    qc = ghz.create_circuit(5)
-    utils.sim_and_print_hist(qc, "pytest")
-    assert os.path.exists("hist_output/pytest_hist.png")
-    if os.path.exists("hist_output/pytest_hist.png"):
-        os.remove("hist_output/pytest_hist.png")
 
 
 def test_dj_constant_oracle():

--- a/mqt/bench/tests/test_all.py
+++ b/mqt/bench/tests/test_all.py
@@ -40,7 +40,6 @@ def test_configure_begin():
     if not os.path.exists(test_qasm_output_path):
         os.mkdir(test_qasm_output_path)
     utils.set_qasm_output_path(test_qasm_output_path)
-    print("test")
     assert utils.get_qasm_output_path() == test_qasm_output_path
 
 

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,9 @@ setup(
     url="https://github.com/cda-tum/mqtbench",
     keywords="mqt quantum benchmarking performance testing",
     install_requires=[
-        "matplotlib==3.5.1",
         "qiskit==0.35",
-        "pandas==1.4.0",
+        "qiskit[visualization]==0.35.0",
+        "pandas==1.3.5",
         "flask==2.1.2",
         "networkx==2.8.3",
         "pytest==7.1.1",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
     url="https://github.com/cda-tum/mqtbench",
     keywords="mqt quantum benchmarking performance testing",
     install_requires=[
-        "qiskit==0.35",
         "qiskit[visualization]==0.35.0",
         "pandas==1.3.5",
         "flask==2.1.2",


### PR DESCRIPTION
Removed functionalities (as listed in #48) for:

- printing the circuits for the created benchmarks
- simulating and saving the histogram for the created benchmarks