### PR TITLE
👷 update github action to publish to pypi

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,9 +65,8 @@ jobs:
         with:
           name: artifact
           path: dist
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.pypi_password }}
           skip_existing: true
           verbose: true


### PR DESCRIPTION
The `master` branch of the `gh-action-pypi-publish` action has been deprecated in July.
This tiny PR updates the action to the recommended usage from [https://github.com/pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish).