### PR TITLE
Fix oqc qasm

### DIFF
--- a/mqt/bench/benchmark_generator.py
+++ b/mqt/bench/benchmark_generator.py
@@ -617,9 +617,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     print("#### Start generating")
-    # create_benchmarks_from_config(args.file_name)
-    print("#### Start preprocessing")
-    utils.postprocess_oqc_qasm_files()
+    create_benchmarks_from_config(args.file_name)
     print("#### Start zipping")
-    # utils.create_zip_file()
+    utils.create_zip_file()
     print("#### Generation ended")

--- a/mqt/bench/utils/utils.py
+++ b/mqt/bench/utils/utils.py
@@ -319,8 +319,7 @@ def get_molecule(benchmark_instance_name: str):
 
 
 def postprocess_single_oqc_file(filename: str):
-
-    if "oqc_lucy_qiskit" in filename or "nativegates_oqc_qiskit" in filename:
+    if "mapped_oqc_lucy_qiskit" in filename or "nativegates_oqc_qiskit" in filename:
         with open(filename) as f:
             lines = f.readlines()
         with open(filename, "w") as f:
@@ -331,24 +330,8 @@ def postprocess_single_oqc_file(filename: str):
                     f.write(line)
                 if "gate ecr" in line.strip("\n"):
                     f.write("opaque ecr q0,q1;\n")
-    elif "oqc_qiskit" in filename:
-        with open(filename) as f:
-            lines = f.readlines()
-        with open(filename, "w") as f:
-            for line in lines:
-                if not (
-                    "gate rzx" in line.strip("\n") or "gate ecr" in line.strip("\n")
-                ):
-                    f.write(line)
-                if "gate ecr" in line.strip("\n"):
-                    f.write(
-                        "gate rzx(param0) q0,q1 { h q1; cx q0,q1; rz(param0) q1; cx q0,q1; h q1; }\n"
-                    )
-                    f.write(
-                        "gate ecr q0,q1 { rzx(pi/4) q0,q1; x q0; rzx(-pi/4) q0,q1; }\n"
-                    )
 
-    elif "oqc_lucy_tket" in filename or "nativegates_oqc_tket" in filename:
+    elif "mapped_oqc_lucy_tket" in filename or "nativegates_oqc_tket" in filename:
         with open(filename) as f:
             lines = f.readlines()
         with open(filename, "w") as f:
@@ -358,22 +341,6 @@ def postprocess_single_oqc_file(filename: str):
                 count += 1
                 if count == 9:
                     f.write("opaque ecr q0,q1;\n")
-
-    elif "oqc_tket" in filename:
-        with open(filename) as f:
-            lines = f.readlines()
-        with open(filename, "w") as f:
-            count = 0
-            for line in lines:
-                f.write(line)
-                count += 1
-                if count == 9:
-                    f.write(
-                        "gate rzx(param0) q0,q1 { h q1; cx q0,q1; rz(param0) q1; cx q0,q1; h q1; }\n"
-                    )
-                    f.write(
-                        "gate ecr q0,q1 { rzx(pi/4) q0,q1; x q0; rzx(-pi/4) q0,q1; }\n"
-                    )
 
     assert QuantumCircuit.from_qasm_file(filename)
     print("New qasm file for: ", filename)

--- a/mqt/bench/utils/utils.py
+++ b/mqt/bench/utils/utils.py
@@ -311,28 +311,26 @@ def get_molecule(benchmark_instance_name: str):
 
 
 def postprocess_single_oqc_file(filename: str):
-    if "mapped_oqc_lucy_qiskit" in filename or "nativegates_oqc_qiskit" in filename:
+    if "oqc" in filename and ("nativegates" in filename or "mapped" in filename):
         with open(filename) as f:
             lines = f.readlines()
-        with open(filename, "w") as f:
-            for line in lines:
-                if not (
-                    "gate rzx" in line.strip("\n") or "gate ecr" in line.strip("\n")
-                ):
+        if "qiskit" in filename:
+            with open(filename, "w") as f:
+                for line in lines:
+                    if not (
+                        "gate rzx" in line.strip("\n") or "gate ecr" in line.strip("\n")
+                    ):
+                        f.write(line)
+                    if "gate ecr" in line.strip("\n"):
+                        f.write("opaque ecr q0,q1;\n")
+        elif "tket" in filename:
+            with open(filename, "w") as f:
+                count = 0
+                for line in lines:
                     f.write(line)
-                if "gate ecr" in line.strip("\n"):
-                    f.write("opaque ecr q0,q1;\n")
-
-    elif "mapped_oqc_lucy_tket" in filename or "nativegates_oqc_tket" in filename:
-        with open(filename) as f:
-            lines = f.readlines()
-        with open(filename, "w") as f:
-            count = 0
-            for line in lines:
-                f.write(line)
-                count += 1
-                if count == 9:
-                    f.write("opaque ecr q0,q1;\n")
+                    count += 1
+                    if count == 9:
+                        f.write("opaque ecr q0,q1;\n")
 
     assert QuantumCircuit.from_qasm_file(filename)
     print("New qasm file for: ", filename)

--- a/mqt/bench/utils/utils.py
+++ b/mqt/bench/utils/utils.py
@@ -310,14 +310,6 @@ def get_molecule(benchmark_instance_name: str):
     return instances[benchmark_instance_name]
 
 
-# def postprocess_oqc_qasm_files():
-#     directory = get_qasm_output_path()
-#     Parallel(n_jobs=-1, verbose=100)(
-#         delayed(postprocess_single_oqc_file)(directory, filename)
-#         for filename in os.listdir(directory)
-#     )
-
-
 def postprocess_single_oqc_file(filename: str):
     if "mapped_oqc_lucy_qiskit" in filename or "nativegates_oqc_qiskit" in filename:
         with open(filename) as f:


### PR DESCRIPTION
It was meant to solve #95 but actually the problem was never present for the `get_one_benchmark` method since that method always returns the Qiskit::QuantumCircuit object. Nevertheless, the OQC error handling is improved:

- It is done now immediately after creation.
- The `opaque` function of OpenQASM is now used to avoid introducing non-native gates in the native and mapped levels.
