### PR TITLE
Fix a typo in abstraction level selection block

### DIFF
--- a/mqt/benchviewer/templates/index.html
+++ b/mqt/benchviewer/templates/index.html
@@ -207,7 +207,7 @@
         <p class="text-justify" style="margin: 0px">
           Next, abstraction levels for the selected benchmarks must be chosen.
           There are four available levels ranging from a rather high level
-          description on the algorithm level towards a rath lower level
+          description on the algorithm level towards a rather lower level
           description on the target-dependent: mapped level. For details, see
           <a href="description" target="_blank">the level description</a>.
         </p>


### PR DESCRIPTION
I think the word is meant to be "rather". =)