### PR TITLE
🐛 Quick-fix for uni-directional routing with TKET

### DIFF
--- a/mqt/bench/tests/test_all.py
+++ b/mqt/bench/tests/test_all.py
@@ -240,6 +240,24 @@ def test_routing():
     assert qc.depth() > 0
 
 
+def test_unidirectional_coupling_map():
+    from pytket.architecture import Architecture
+
+    qc = get_benchmark(
+        benchmark_name="dj",
+        level="mapped",
+        circuit_size=3,
+        compiler="tket",
+        compiler_settings={"tket": {"placement": "graphplacement"}},
+        gate_set_name="oqc",
+        device_name="oqc_lucy",
+    )
+    # check that all gates in the circuit are in the coupling map
+    assert qc.valid_connectivity(
+        arch=Architecture(utils.get_cmap_oqc_lucy()), directed=True
+    )
+
+
 @pytest.mark.parametrize(
     "benchmark_name, level, circuit_size, benchmark_instance_name, compiler, compiler_settings, gate_set_name, device_name,",
     [

--- a/mqt/bench/tests/test_all.py
+++ b/mqt/bench/tests/test_all.py
@@ -52,7 +52,7 @@ def test_configure_begin():
     [
         (ae, 8, True),
         (ghz, 5, True),
-        (dj, 5, True),
+        (dj, 3, True),
         (graphstate, 8, True),
         (grover, 5, False),
         (hhl, 2, False),
@@ -99,7 +99,7 @@ def test_quantumcircuit_indep_level(benchmark, input_value, scalable):
     [
         (ae, 8, True),
         (ghz, 5, True),
-        (dj, 5, True),
+        (dj, 3, True),
         (graphstate, 8, True),
         (grover, 5, False),
         (qaoa, 5, True),

--- a/mqt/bench/utils/tket_helper.py
+++ b/mqt/bench/utils/tket_helper.py
@@ -279,6 +279,7 @@ def get_mapped_level(
             placer = GraphPlacement(arch)
         PlacementPass(placer).apply(qc_tket)
         RoutingPass(arch).apply(qc_tket)
+        native_gate_set_rebase.apply(qc_tket)
         if not qc_tket.valid_connectivity(arch, directed=True):
             CXMappingPass(arc=arch, placer=placer, directed_cx=True).apply(qc_tket)
         native_gate_set_rebase.apply(qc_tket)

--- a/mqt/bench/utils/tket_helper.py
+++ b/mqt/bench/utils/tket_helper.py
@@ -5,6 +5,7 @@ from os import path
 from pytket import OpType, architecture, circuit
 from pytket.extensions.qiskit import qiskit_to_tk
 from pytket.passes import (
+    CXMappingPass,
     FullPeepholeOptimise,
     PlacementPass,
     RoutingPass,
@@ -273,10 +274,13 @@ def get_mapped_level(
         native_gate_set_rebase.apply(qc_tket)
         FullPeepholeOptimise(target_2qb_gate=OpType.TK2).apply(qc_tket)
         if lineplacement:
-            PlacementPass(LinePlacement(arch)).apply(qc_tket)
+            placer = LinePlacement(arch)
         else:
-            PlacementPass(GraphPlacement(arch)).apply(qc_tket)
+            placer = GraphPlacement(arch)
+        PlacementPass(placer).apply(qc_tket)
         RoutingPass(arch).apply(qc_tket)
+        if not qc_tket.valid_connectivity(arch, directed=True):
+            CXMappingPass(arc=arch, placer=placer, directed_cx=True).apply(qc_tket)
         native_gate_set_rebase.apply(qc_tket)
         if return_qc:
             return qc_tket

--- a/mqt/bench/utils/tket_helper.py
+++ b/mqt/bench/utils/tket_helper.py
@@ -279,6 +279,9 @@ def get_mapped_level(
             placer = GraphPlacement(arch)
         PlacementPass(placer).apply(qc_tket)
         RoutingPass(arch).apply(qc_tket)
+        FullPeepholeOptimise(target_2qb_gate=OpType.TK2, allow_swaps=False).apply(
+            qc_tket
+        )
         native_gate_set_rebase.apply(qc_tket)
         if not qc_tket.valid_connectivity(arch, directed=True):
             CXMappingPass(arc=arch, placer=placer, directed_cx=True).apply(qc_tket)

--- a/mqt/bench/utils/tket_helper.py
+++ b/mqt/bench/utils/tket_helper.py
@@ -284,7 +284,9 @@ def get_mapped_level(
         )
         native_gate_set_rebase.apply(qc_tket)
         if not qc_tket.valid_connectivity(arch, directed=True):
-            CXMappingPass(arc=arch, placer=placer, directed_cx=True).apply(qc_tket)
+            CXMappingPass(
+                arc=arch, placer=placer, directed_cx=True, delay_measures=False
+            ).apply(qc_tket)
         native_gate_set_rebase.apply(qc_tket)
         if return_qc:
             return qc_tket


### PR DESCRIPTION
Resolves #169.

⚡  also adds a new post-mapping, layout-preserving optimization pass for tket that should improve its results.