### PR TITLE
Fix Typos

### DIFF
--- a/src/mqt/benchviewer/templates/description.html
+++ b/src/mqt/benchviewer/templates/description.html
@@ -82,7 +82,7 @@
           representations of the circuits from the algorithmic level.
         </li>
         <li>
-          <em>Target-dependent Native-Gates Level</em>: Circuits are synthesized
+          <em>Target-dependent Native Gates Level</em>: Circuits are synthesized
           to a particular native gate-set.
         </li>
         <li>

--- a/src/mqt/benchviewer/templates/index.html
+++ b/src/mqt/benchviewer/templates/index.html
@@ -207,8 +207,8 @@
         <p class="text-justify" style="margin: 0px">
           Next, abstraction levels for the selected benchmarks must be chosen.
           There are four available levels ranging from a rather high level
-          description on the algorithm level towards a rather lower level
-          description on the target-dependent: mapped level. For details, see
+          description on the algorithm level towards a rather low level
+          description on the target-dependent mapped level. For details, see
           <a href="description" target="_blank">the level description</a>.
         </p>
       </div>
@@ -269,7 +269,7 @@
             class="col border border-secondary"
             style="width: 25%; min-width: 200px; margin: 1px"
           >
-            <h6>Target-dependent: Native-Gates Level</h6>
+            <h6>Target-dependent Native Gates Level</h6>
 
             <p class="text-justify" style="margin: 0px">
               Select targeted native gate-set:
@@ -385,7 +385,7 @@
             class="col border border-secondary"
             style="width: 25%; min-width: 200px; margin: 1px"
           >
-            <h6>Target-dependent: Mapped Level</h6>
+            <h6>Target-dependent Mapped Level</h6>
             <p class="text-justify" style="margin: 0px">
               Select a targeted device:
             </p>
@@ -446,7 +446,9 @@
                     value="true"
                     name="device_ionq_ionq11"
                   />
-                  <label for="device_ionq_ionq11">IonQ (11 Qubits) </label>
+                  <label for="device_ionq_ionq11"
+                    >IonQ Harmony (11 Qubits)
+                  </label>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Fixed typos:
- Renamed "IonQ" device to "IonQ Harmony" to be consistent with the paper 
- Removed ":" in Level Names to be consistent with the paper 
- Changed "Native-Gates" to "Native Gates" to be consistent with the paper 